### PR TITLE
Add check valve support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Here are some of the planned developments for this Workbench:
     - [ ] Gate Valve
     - [ ] Plug Valve
     - [X] Ball Valve
-    - [ ] Check Valve
+    - [X] Check Valve
     - [ ] Globe Valve
     - [X] Butterfly Valve
     - [ ] Needle Valve

--- a/pFeatures.py
+++ b/pFeatures.py
@@ -2347,13 +2347,107 @@ class Valve(pypeType):
         ]
 
     def _execute_legacy(self, fp, H):
+        if fp.PRating.lower().find("check") + 1:
+            self._execute_check_wafer(fp, H)
+            return
+
         c = Part.makeCone(fp.ODBody / 2, fp.ODBody / 5, H / 2,
                           FreeCAD.Vector(0, 0, -H / 2))
         v = c.fuse(c.mirror(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1)))
-        if fp.PRating.find("ball") + 1 or fp.PRating.find("globe") + 1:
+        if fp.PRating.lower().find("ball") + 1 or fp.PRating.lower().find("globe") + 1:
             r = min(H * 0.45, float(fp.ODBody) / 2)
             v = v.fuse(Part.makeSphere(r, FreeCAD.Vector(0, 0, 0)))
         fp.Shape = v
+        fp.Ports = [
+            FreeCAD.Vector(0, 0, -H / 2),
+            FreeCAD.Vector(0, 0,  H / 2),
+        ]
+        fp.PortDirections = [
+            FreeCAD.Vector(0, 0, -1),
+            FreeCAD.Vector(0, 0,  1),
+        ]
+
+    def _execute_check_wafer(self, fp, H):
+        """Build a simple wafer-style swing check valve body.
+
+        The roadmap calls out check valves separately from the existing ball and
+        butterfly entries.  This keeps the generic valve table format while
+        giving check valves a distinct directional body, internal tilted disc,
+        and hinge boss instead of the legacy double-cone symbol.
+        """
+        od_body = float(fp.ODBody)
+        bore = float(fp.ID)
+        body = Part.makeCylinder(
+            od_body / 2,
+            H,
+            FreeCAD.Vector(0, 0, -H / 2),
+            FreeCAD.Vector(0, 0, 1),
+        )
+        bore_cut = Part.makeCylinder(
+            bore / 2,
+            H + 2,
+            FreeCAD.Vector(0, 0, -H / 2 - 1),
+            FreeCAD.Vector(0, 0, 1),
+        )
+        body = body.cut(bore_cut)
+
+        ring_h = max(2.0, min(H * 0.18, 8.0))
+        ring_od = min(od_body, bore + (od_body - bore) * 0.65)
+        ring_id = bore * 0.86
+        rings = []
+        for z0 in (-H / 2, H / 2 - ring_h):
+            ring = Part.makeCylinder(
+                ring_od / 2,
+                ring_h,
+                FreeCAD.Vector(0, 0, z0),
+                FreeCAD.Vector(0, 0, 1),
+            )
+            ring_bore = Part.makeCylinder(
+                ring_id / 2,
+                ring_h + 2,
+                FreeCAD.Vector(0, 0, z0 - 1),
+                FreeCAD.Vector(0, 0, 1),
+            )
+            rings.append(ring.cut(ring_bore))
+
+        disc_thk = max(2.0, min(H * 0.12, 6.0))
+        disc = Part.makeCylinder(
+            bore * 0.38,
+            disc_thk,
+            FreeCAD.Vector(0, 0, -disc_thk / 2),
+            FreeCAD.Vector(0, 0, 1),
+        )
+        disc.rotate(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1, 0, 0), 22)
+
+        hinge_radius = max(2.0, min(H * 0.16, bore * 0.08))
+        hinge_y = od_body / 2 + hinge_radius * 0.2
+        hinge = Part.makeCylinder(
+            hinge_radius,
+            od_body * 0.7,
+            FreeCAD.Vector(-od_body * 0.35, hinge_y, 0),
+            FreeCAD.Vector(1, 0, 0),
+        )
+        hinge_web = Part.makeCylinder(
+            hinge_radius * 0.65,
+            od_body * 0.16,
+            FreeCAD.Vector(0, od_body / 2 - hinge_radius * 0.8, 0),
+            FreeCAD.Vector(0, 1, 0),
+        )
+        disc_arm = Part.makeCylinder(
+            hinge_radius * 0.42,
+            hinge_y,
+            FreeCAD.Vector(0, 0, 0),
+            FreeCAD.Vector(0, 1, 0),
+        )
+
+        valve = body
+        for ring in rings:
+            valve = valve.fuse(ring)
+        valve = valve.fuse(disc)
+        valve = valve.fuse(disc_arm)
+        valve = valve.fuse(hinge)
+        valve = valve.fuse(hinge_web)
+        fp.Shape = valve.removeSplitter()
         fp.Ports = [
             FreeCAD.Vector(0, 0, -H / 2),
             FreeCAD.Vector(0, 0,  H / 2),

--- a/tablez/Valve_check_wafer.csv
+++ b/tablez/Valve_check_wafer.csv
@@ -1,0 +1,7 @@
+PSize;VType;ODBody;ID;H;Kv
+DN50;check_wafer;107;43.3;43;0
+DN65;check_wafer;127;60.2;46;0
+DN80;check_wafer;142;66.4;64;0
+DN100;check_wafer;162;90.8;64;0
+DN125;check_wafer;192;116.9;70;0
+DN150;check_wafer;218;144.6;76;0


### PR DESCRIPTION
## Summary
- add a `Valve_check_wafer.csv` valve table so check valves appear in the standard valve insertion form
- render `check_*` legacy valve ratings with a distinct wafer-style check valve body, tilted internal disc, and hinge boss
- mark Check Valve complete in the README roadmap

## Screenshot
![DN100 check_wafer preview](https://raw.githubusercontent.com/gitgrahamdunn/quetzal/pr-assets-check-valve-screenshot/pr-assets/check_wafer_DN100_preview.png)

## Catalog dimensions
- source: Yaxing wafer dual-plate check valve catalog table (`DN`, `L`, `D`, `D2`)
- CSV mapping: `D` -> `ODBody`, `D2` -> `ID`, `L` -> `H`
- included sizes: DN50, DN65, DN80, DN100, DN125, DN150
- omitted DN40 because this vendor table starts at DN50
- left `Kv` as 0 because the catalog does not provide flow coefficients

Catalog URL: https://www.yaxing-valve.com/check-valve/wafer-dual-plate-check-valve-dn40-dn800.html

## Verification
- `python3 -m py_compile pFeatures.py pCmd.py pForms.py dodoDialogs.py`
- parsed all `tablez/Valve_*.csv` files with Python `csv.DictReader`
- validated `tablez/Valve_check_wafer.csv` schema and numeric fields
- regenerated DN100 with FreeCAD command line from the CSV-backed dimensions and visually checked the STL preview
