### PR TITLE
Add beam clamp support

### DIFF
--- a/CPipe.py
+++ b/CPipe.py
@@ -209,7 +209,7 @@ class insertUbolt:
     def GetResources(self):
         return {
             "Pixmap": "Quetzal_InsertUBolt",
-            "MenuText": QT_TRANSLATE_NOOP("Quetzal_InsertUbolt", "Insert a U-bolt"),
+            "MenuText": QT_TRANSLATE_NOOP("Quetzal_InsertUbolt", "Insert a clamp"),
             "ToolTip": QT_TRANSLATE_NOOP("Quetzal_InsertUbolt", Quetzal_tooltips.ubolt_tooltip),
         }
 

--- a/Quetzal_tooltips.py
+++ b/Quetzal_tooltips.py
@@ -218,14 +218,15 @@ flange_tooltip = (
 )
 
 ubolt_tooltip = (
-    "Tool to insert U-bolt pipe supports\n"
+    "Tool to insert pipe clamps\n"
     "______________________________________________________________________________________________________________________________________ \n"
     "Usage \n"
     "Select a pipe object to attach U-bolts along it \n"
     " • If a pipe object is selected, the U-bolt size is automatically matched to the pipe's nominal diameter. U-bolts may be inserted at the head (near Port 0), middle, and/or tail (near Port 1) of the pipe using the check boxes. \n"
-    " • If no objects are selected, a single U-bolt will be inserted at the origin. \n"
+    " • If no objects are selected, a single clamp will be inserted at the origin. \n"
+    " • Beam clamp rows are inserted as standalone beam clamps. If a face or object is selected, the beam clamp is placed at that selection. \n"
     "\n"
-    "In the window, select the U-bolt standard from the rating list, then select the nominal pipe size from the size list.\n"
+    "In the window, select the clamp standard from the rating list, then select the size from the size list.\n"
     "Use the check boxes to select the insertion positions along the pipe:\n"
     " • Head: inserts a U-bolt offset from Port 0 by half the U-bolt width (C dimension).\n"
     " • Middle: inserts a U-bolt at the midpoint of the pipe.\n"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here are some of the planned developments for this Workbench:
     - [ ] Pinch Valve
   - [ ] Pipe Clamping
     - [X] U-bolt clamp
-    - [ ] Beam clamp
+    - [X] Beam clamp
   - [ ] Beam joins
 - [ ] Support, if possible, International design standarts:
   - [ ] ASME B16.5 (NPS 1/2 to 24")

--- a/pCmd.py
+++ b/pCmd.py
@@ -1318,6 +1318,35 @@ def makeUbolt(propList=[], pos=None, Z=None):
     return a
 
 
+def makeBeamClamp(propList=[], pos=None, Z=None):
+    """Adds a beam clamp object:
+    makeBeamClamp(propList,pos,Z);
+      propList is one optional list with 9 elements:
+        PSize (string): catalog size row
+        ClampType (string): the clamp type or standard
+        ProductCode (string): vendor product code
+        Bolt (string): nominal bolt size
+        Y, X, V, T, W (float): catalog dimensions in mm
+      pos (vector): position of insertion; default = 0,0,0
+      Z (vector): orientation: default = 0,0,1
+    """
+    if pos == None:
+        pos = FreeCAD.Vector(0, 0, 0)
+    if Z == None:
+        Z = FreeCAD.Vector(0, 0, 1)
+    a = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Beam-Clamp")
+    if len(propList) == 9:
+        pFeatures.BeamClamp(a, *propList)
+    else:
+        pFeatures.BeamClamp(a)
+    ViewProvider(a.ViewObject, "Quetzal_InsertUBolt")
+    a.Placement.Base = pos
+    rot = FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), Z)
+    a.Placement.Rotation = rot.multiply(a.Placement.Rotation)
+    a.Label = translate("Objects", "Beam Clamp")
+    return a
+
+
 def makeShell(L=1000, W=1500, H=1500, thk1=6, thk2=8):
     """
     makeShell(L,W,H,thk1,thk2)

--- a/pFeatures.py
+++ b/pFeatures.py
@@ -4,7 +4,7 @@ __title__ = "pypeTools objects"
 __author__ = "oddtopus"
 __url__ = "github.com/oddtopus/dodo"
 __license__ = "LGPL 3"
-objs = ["Pipe", "Elbow", "Reduct", "Cap", "Flange", "Tee", "Ubolt", "Valve"]
+objs = ["Pipe", "Elbow", "Reduct", "Cap", "Flange", "Tee", "Ubolt", "BeamClamp", "Valve"]
 metaObjs = ["PypeLine", "PypeBranch"]
 
 from os.path import abspath, dirname, join
@@ -1670,6 +1670,155 @@ class Ubolt:
         path = Part.Wire([c, l1, l2])
         fp.Shape = path.makePipe(p)
         fp.Ports = [FreeCAD.Vector(0, 0, 1)] #not quite sure why a U-bolt has a port?
+
+
+class BeamClamp:
+    """Class for object PType="Clamp".
+    BeamClamp(obj,[PSize="LA037-short", ClampType="Beam", ProductCode="LA037",
+                   Bolt="M10", Y=20, X=11, V=4, T=5, W=26])
+      obj: the "App::FeaturePython" object
+      PSize (string): catalog size row
+      ClampType (string): clamp family
+      ProductCode (string): vendor product code
+      Bolt (string): nominal fastener size
+      Y, X, V, T, W (float): catalog dimensions in mm
+    """
+
+    def __init__(
+        self,
+        obj,
+        PSize="LA037-short",
+        ClampType="Beam",
+        ProductCode="LA037",
+        Bolt="M10",
+        Y=20,
+        X=11,
+        V=4,
+        T=5,
+        W=26,
+    ):
+        obj.Proxy = self
+        obj.addProperty(
+            "App::PropertyString",
+            "PType",
+            "BeamClamp",
+            QT_TRANSLATE_NOOP("App::Property", "Type of pipeFeature"),
+        ).PType = "Clamp"
+        obj.addProperty(
+            "App::PropertyString",
+            "ClampType",
+            "BeamClamp",
+            QT_TRANSLATE_NOOP("App::Property", "Type of clamp"),
+        ).ClampType = ClampType
+        obj.addProperty(
+            "App::PropertyString",
+            "PSize",
+            "BeamClamp",
+            QT_TRANSLATE_NOOP("App::Property", "Size of clamp"),
+        ).PSize = PSize
+        obj.addProperty(
+            "App::PropertyString",
+            "ProductCode",
+            "BeamClamp",
+            QT_TRANSLATE_NOOP("App::Property", "Catalog product code"),
+        ).ProductCode = ProductCode
+        obj.addProperty(
+            "App::PropertyString",
+            "Bolt",
+            "BeamClamp",
+            QT_TRANSLATE_NOOP("App::Property", "Bolt size"),
+        ).Bolt = Bolt
+        for prop, value, text in [
+            ("Y", Y, "Clamp height"),
+            ("X", X, "Clamp body length"),
+            ("V", V, "Tail length"),
+            ("T", T, "Clamp thickness"),
+            ("W", W, "Clamp width"),
+        ]:
+            obj.addProperty(
+                "App::PropertyLength",
+                prop,
+                "BeamClamp",
+                QT_TRANSLATE_NOOP("App::Property", text),
+            )
+            setattr(obj, prop, value)
+        obj.addProperty(
+            "App::PropertyVectorList",
+            "Ports",
+            "PBase",
+            QT_TRANSLATE_NOOP("App::Property", "Ports position relative to the origin of Shape"),
+        )
+        self.execute(obj)
+
+    def onChanged(self, fp, prop):
+        return None
+
+    def execute(self, fp):
+        height = float(fp.Y)
+        body_len = float(fp.X)
+        tail_len = float(fp.V)
+        thk = float(fp.T)
+        width = float(fp.W)
+        bolt_dia = self._bolt_diameter(fp.Bolt, max(height * 0.5, 1))
+
+        body = Part.makeBox(
+            body_len,
+            width,
+            height,
+            FreeCAD.Vector(-body_len / 2, -width / 2, 0),
+        )
+        tail = Part.makeBox(
+            tail_len,
+            width,
+            thk,
+            FreeCAD.Vector(body_len / 2, -width / 2, 0),
+        )
+        nose = Part.makeBox(
+            thk,
+            width,
+            thk,
+            FreeCAD.Vector(-body_len / 2 - thk, -width / 2, -thk),
+        )
+        lower_grip = Part.makeBox(
+            max(body_len * 0.45, thk),
+            width,
+            thk,
+            FreeCAD.Vector(-body_len / 2, -width / 2, -thk),
+        )
+        boss = Part.makeCylinder(
+            bolt_dia * 0.75,
+            thk,
+            FreeCAD.Vector(0, 0, height),
+            vZ,
+        )
+        clearance = Part.makeCylinder(
+            bolt_dia * 0.58,
+            height + thk * 3,
+            FreeCAD.Vector(0, 0, -thk * 1.5),
+            vZ,
+        )
+        clamp = body.fuse(tail).fuse(nose).fuse(lower_grip).fuse(boss).cut(clearance)
+        bolt = Part.makeCylinder(
+            bolt_dia * 0.42,
+            height + thk * 3,
+            FreeCAD.Vector(0, 0, -thk * 1.5),
+            vZ,
+        )
+        head = Part.makeCylinder(
+            bolt_dia * 0.85,
+            thk * 0.8,
+            FreeCAD.Vector(0, 0, height + thk),
+            vZ,
+        )
+        fp.Shape = clamp.fuse(bolt).fuse(head)
+        fp.Ports = [FreeCAD.Vector(0, 0, 0)]
+
+    def _bolt_diameter(self, bolt, fallback):
+        try:
+            return float(str(bolt).strip().upper().replace("M", ""))
+        except Exception:
+            return fallback
+
 
 class Shell:
     """

--- a/pForms.py
+++ b/pForms.py
@@ -1888,7 +1888,7 @@ class insertReductForm(dodoDialogs.protoPypeForm):
 
 class insertUboltForm(dodoDialogs.protoPypeForm):
     """
-    Dialog to insert U-bolts.
+    Dialog to insert pipe clamps.
     For position and orientation you can select
       - one or more circular edges,
       - nothing.
@@ -1898,7 +1898,7 @@ class insertUboltForm(dodoDialogs.protoPypeForm):
 
     def __init__(self):
         super(insertUboltForm, self).__init__(
-            translate("insertUboltForm", "Insert U-bolt"),
+            translate("insertUboltForm", "Insert clamp"),
             "Clamp",
             "DIN-UBolt",
             "clamp.svg",
@@ -1929,6 +1929,32 @@ class insertUboltForm(dodoDialogs.protoPypeForm):
         self.refNorm = None
         self.getReference()
 
+    def _isBeamClamp(self, row):
+        return row.get("ClampFamily", "").strip().lower() == "beam" or "ProductCode" in row
+
+    def _beamClampPropList(self, row):
+        return [
+            row["PSize"],
+            row.get("ClampFamily", self.PRating),
+            row.get("ProductCode", ""),
+            row.get("Bolt", ""),
+            float(pq(row["Y"])),
+            float(pq(row["X"])),
+            float(pq(row["V"])),
+            float(pq(row["T"])),
+            float(pq(row["W"])),
+        ]
+
+    def _selectedClampPosition(self, selex):
+        for sx in selex:
+            if sx.SubObjects:
+                for sub in sx.SubObjects:
+                    if hasattr(sub, "CenterOfMass"):
+                        return sub.CenterOfMass
+            if hasattr(sx.Object, "Placement"):
+                return sx.Object.Placement.Base
+        return FreeCAD.Vector(0, 0, 0)
+
     def getReference(self):
         selex = FreeCADGui.Selection.getSelectionEx()
         for sx in selex:
@@ -1941,12 +1967,26 @@ class insertUboltForm(dodoDialogs.protoPypeForm):
 
     def insert(self):
         selex = FreeCADGui.Selection.getSelectionEx()
+        _idx = self.sizeList.currentIndex()
+        if _idx < 0 or _idx >= len(self.pipeDictList):
+            return
+        current_row = self.pipeDictList[_idx]
+        if self._isBeamClamp(current_row):
+            FreeCAD.activeDocument().openTransaction(
+                translate("Transaction", "Insert beam clamp")
+            )
+            bc = pCmd.makeBeamClamp(
+                self._beamClampPropList(current_row),
+                pos=self._selectedClampPosition(selex),
+            )
+            if self.existingObjs.currentText() != "<none>":
+                pCmd.moveToPyLi(bc, self.existingObjs.currentText())
+            FreeCAD.activeDocument().commitTransaction()
+            FreeCAD.activeDocument().recompute()
+            return
         if len(selex) == 0:
             # size_selected = self.pipeDictList[self.sizeList.currentIndex()]
-            _idx = self.sizeList.currentIndex()
-            if _idx < 0 or _idx >= len(self.pipeDictList):
-                return
-            size_selected = self.pipeDictList[_idx]
+            size_selected = current_row
             rating = self.ratingList.currentText()
             propList = [
                 size_selected["PSize"],

--- a/tablez/Clamp_Beam.csv
+++ b/tablez/Clamp_Beam.csv
@@ -1,0 +1,16 @@
+PSize;ClampFamily;ProductCode;Bolt;Tail;Y;X;V;T;W;TorqueNm;Source
+LA037-short;Beam;LA037;M10;short;20;11;4;5;26;20;https://www.lindapter.com/us/product/type-a
+LA037-medium;Beam;LA037;M10;medium;20;11;5;5;26;20;https://www.lindapter.com/us/product/type-a
+LA037-long;Beam;LA037;M10;long;20;11;7;5;26;20;https://www.lindapter.com/us/product/type-a
+LA050-short;Beam;LA050;M12;short;26;13;4.5;6;29;69;https://www.lindapter.com/us/product/type-a
+LA050-medium;Beam;LA050;M12;medium;26;13;6;6;29;69;https://www.lindapter.com/us/product/type-a
+LA050-long;Beam;LA050;M12;long;26;13;9.5;6;29;69;https://www.lindapter.com/us/product/type-a
+LA062-short;Beam;LA062;M16;short;30;16;5.5;8;36;147;https://www.lindapter.com/us/product/type-a
+LA062-medium;Beam;LA062;M16;medium;30;16;8;8;36;147;https://www.lindapter.com/us/product/type-a
+LA062-long;Beam;LA062;M16;long;30;16;11;8;36;147;https://www.lindapter.com/us/product/type-a
+LA075-short;Beam;LA075;M20;short;36;19;7;10;46;285;https://www.lindapter.com/us/product/type-a
+LA075-medium;Beam;LA075;M20;medium;36;19;10;10;46;285;https://www.lindapter.com/us/product/type-a
+LA075-long;Beam;LA075;M20;long;36;19;12.5;10;46;285;https://www.lindapter.com/us/product/type-a
+LA100-short;Beam;LA100;M24;short;48;29;9;13;55;491;https://www.lindapter.com/us/product/type-a
+LA100-medium;Beam;LA100;M24;medium;48;29;12;13;55;491;https://www.lindapter.com/us/product/type-a
+LA100-long;Beam;LA100;M24;long;48;29;16;13;55;491;https://www.lindapter.com/us/product/type-a


### PR DESCRIPTION
## Summary
- adds beam clamp support under the existing clamp insertion command
- adds `Clamp_Beam.csv` with Lindapter Type A metric catalog dimensions for LA037, LA050, LA062, LA075, and LA100 in short/medium/long tail variants
- updates the clamp form to insert beam clamp rows as standalone clamp objects while preserving existing U-bolt pipe placement behavior
- marks the README roadmap beam clamp item complete

## Source Data
Dimensions are from Lindapter Type A metric product data: https://www.lindapter.com/us/product/type-a

Mapped fields:
- `Y`, `X`, `V`, `T`, `W`, and `TorqueNm` are copied from the Lindapter Type A metric dimensions table.
- `V` is expanded into short, medium, and long tail rows.

## Preview
![Beam clamp preview](https://gist.githubusercontent.com/gitgrahamdunn/59717eade689aa75b8636d69d371602a/raw/beam_clamp_preview.svg)

## Validation
- `python3 -m py_compile pFeatures.py pCmd.py pForms.py CPipe.py Quetzal_tooltips.py`
- `git diff --check`
- CSV integrity check for all 15 beam clamp rows against the Lindapter Type A dimensions table
- FreeCAD command-mode construction check for `LA075-long` produced one solid with nonzero volume
