### PR TITLE
Remove call to init_toolbar from InitGui.py

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -134,9 +134,8 @@ class QuetzalWorkbench(Workbench):
         import DraftTools
         import draftutils.init_tools as it
 
-        it.init_toolbar(self,
-                        QT_TRANSLATE_NOOP("Workbench", "Draft snap"),
-                        it.get_draft_snap_commands())
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Draft snap"),
+                           it.get_draft_snap_commands())
         self.qm = toolList  # ["pipeQM","elbowQM","reductQM"]
         self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Pipe tools"), self.pypeList)
         Log("Loading Pipe tools: done\n")


### PR DESCRIPTION
Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=22711&start=110#p898824

The init_toolbar function has been removed from the Draft code.