### PR TITLE
Fix three defects that stop pFeatures being used without a GUI

### DIFF
--- a/pCmd.py
+++ b/pCmd.py
@@ -633,6 +633,14 @@ def getSelectionPortAttachment(selex=None):
 
 class ViewProvider:
     def __init__(self, obj, icon_fn):
+        # In console mode DocumentObject.ViewObject is None (FreeCAD returns
+        # Py::None when FreeCADGui has no Gui::Document for the App document),
+        # so every make*() factory died here before it could return its object.
+        # Guarding once, in the provider, covers all 17 call sites and any
+        # added later -- the geometry in pFeatures is pure Part/BRep and has
+        # never needed the GUI.
+        if obj is None or not FreeCAD.GuiUp:
+            return
         obj.Proxy = self
         self._check_attr()
         self.icon_fn = get_icon_path(icon_fn or "quetzal")
@@ -1331,8 +1339,9 @@ def makeShell(L=1000, W=1500, H=1500, thk1=6, thk2=8):
     pFeatures.Shell(a, L, W, H, thk1, thk2)
     ViewProvider(a.ViewObject, "Quetzal_InsertTank")
     a.Placement.Base = FreeCAD.Vector(0, 0, 0)
-    a.ViewObject.ShapeColor = 0.0, 0.0, 1.0
-    a.ViewObject.Transparency = 85
+    if FreeCAD.GuiUp:
+        a.ViewObject.ShapeColor = 0.0, 0.0, 1.0
+        a.ViewObject.Transparency = 85
     FreeCAD.ActiveDocument.recompute()
     a.Label = translate("Objects", "Tank")
     return a
@@ -1593,8 +1602,9 @@ def makePypeLine2(
     if not pl:
         a = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", lab)
         pFeatures.PypeLine2(a, DN, PRating, OD, thk, BR, lab)
-        pFeatures.ViewProviderPypeLine(a.ViewObject)  # a.ViewObject.Proxy=0
-        a.ViewObject.ShapeColor = color
+        if FreeCAD.GuiUp:
+            pFeatures.ViewProviderPypeLine(a.ViewObject)  # a.ViewObject.Proxy=0
+            a.ViewObject.ShapeColor = color
         if len(FreeCADGui.Selection.getSelection()) == 1:
             obj = FreeCADGui.Selection.getSelection()[0]
             isWire = hasattr(obj, "Shape") and obj.Shape.Edges  # type(obj.Shape)==Part.Wire

--- a/pFeatures.py
+++ b/pFeatures.py
@@ -596,19 +596,29 @@ class Flange(pypeType):
                 base = base.cut(hole)
                 hole.rotate(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), 360.0 / fp.n)
         # creates flange thickness
-        flange = base.extrude(FreeCAD.Vector(0, 0, fp.t)) 
-        fp.ViewObject.Deviation = 0.10
+        flange = base.extrude(FreeCAD.Vector(0, 0, fp.t))
+        # Tessellation quality is a display setting, and ViewObject is None in
+        # console mode. Setting it unguarded raised AttributeError mid-execute,
+        # which recompute swallows -- so every Flange came back with a NULL
+        # shape and no error, headless.
+        if FreeCAD.GuiUp and fp.ViewObject is not None:
+            fp.ViewObject.Deviation = 0.10
         if (
             fp.FlangeType == "SW"
             or fp.FlangeType == "WN"
             or fp.FlangeType == "LJ"
             or fp.FlangeType == "SO"
         ):
-            # creates flange neck (corrected for raised face addition)
-            nn = Part.makeCylinder(fp.ODp / 2, fp.T1, vO, vZ).cut(
-                Part.makeCylinder(fp.d / 2, fp.T1, vO, vZ)
-            )
-            flange = flange.fuse(nn)
+            # creates flange neck (corrected for raised face addition).
+            # Only when it has real dimensions: ODp/T1 are documented OPTIONAL,
+            # and building a zero-radius zero-height cylinder produced a
+            # degenerate solid that fused into an invalid shape rather than
+            # being skipped.
+            if fp.ODp > 0 and fp.T1 > 0 and fp.ODp > fp.d:
+                nn = Part.makeCylinder(fp.ODp / 2, fp.T1, vO, vZ).cut(
+                    Part.makeCylinder(fp.d / 2, fp.T1, vO, vZ)
+                )
+                flange = flange.fuse(nn)
             if fp.trf > 0 and fp.drf < fp.D:
                 rf = Part.makeCylinder(fp.drf / 2, fp.trf, vO, vZ * -1).cut(
                     Part.makeCylinder(fp.d / 2, fp.trf, vO, vZ * -1)
@@ -1039,9 +1049,13 @@ class Tee(pypeType):
                 except Exception as e:
                     # Fillet failed -- fall back to unfilleted shape rather than
                     # crashing the whole recompute
+                    # float() because fillet_r is a Base.Quantity, which has no
+                    # numeric __format__ -- the fallback that exists to avoid
+                    # crashing the recompute was itself raising TypeError and
+                    # taking the Tee down with it.
                     FreeCAD.Console.PrintWarning(
                         "Tee fillet failed (r={:.2f}mm): {} -- using unfilleted shape\n"
-                        .format(fillet_r, e)
+                        .format(float(fillet_r), e)
                     )
 
         fp.Shape = Base
@@ -3958,3 +3972,4 @@ class SocketUnion(pypeType):
             FreeCAD.Vector(0, 0,  1),
         ]
         super(SocketUnion, self).execute(fp)  # perform common operations
+

--- a/pFeatures.py
+++ b/pFeatures.py
@@ -2528,6 +2528,8 @@ class Valve(pypeType):
             self._execute_pinch(fp, H)
             return
 
+        rating = fp.PRating.lower()
+
         c = Part.makeCone(fp.ODBody / 2, fp.ODBody / 5, H / 2,
                           FreeCAD.Vector(0, 0, -H / 2))
         v = c.fuse(c.mirror(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1)))


### PR DESCRIPTION
Three independent defects that only appear when the workbench is driven from a
script with no GUI. None of them touches geometry, and each is a few lines.

I found these building piping headlessly under FreeCAD 1.1.0 with
`QT_QPA_PLATFORM=offscreen`. Everything below is reproduced by running it, not
by reading the source.

### 1. `NameError` in `Valve._execute_legacy`

`rating` is read at `pFeatures.py:2534` but never bound, so constructing a
butterfly, globe, wafer-check or generic ball valve raises before it can build
a shape. That is 30 catalogue rows dead:

- `Valve_butterfly_generic.csv` (10)
- `Valve_globePN16_generic.csv` (10)
- `Valve_check_wafer.csv` (6)
- `Valve_ball_generic.csv` (4)

Knife gate and pinch survive only because they early-return above the fault.

This is a regression rather than legacy rot: commit a75e751 ("Add gate valve
support", #38) replaced `fp.PRating.find(...)` with a bare `rating.find(...)`
without binding the local. Fixed by binding `rating = fp.PRating.lower()`,
which also makes it case-insensitive like the early-returns just above.

### 2. `ViewProvider` assumes a GUI

In console mode `DocumentObject.ViewObject` is `None` — FreeCAD returns
`Py::None` when FreeCADGui holds no `Gui::Document` for the App document — so
`obj.Proxy = self` raises `AttributeError` and every `make*()` factory dies
before returning its object.

Guarding once inside `ViewProvider` covers all 17 call sites and any added
later. Two direct `ViewObject` attribute writes (`makeTank`'s colour and
transparency, `makePypeLine2`'s provider) are guarded the same way, on the
pattern `fFeatures.py:1540` already uses for Draft.

### 3. `Flange` returns a null shape, `Tee` crashes in its own error handler

`Flange.execute` sets `fp.ViewObject.Deviation` unconditionally. Headless, the
`AttributeError` is swallowed by recompute and every flange comes back NULL
with nothing to say why.

`Tee`'s fillet fallback raises inside itself: `fillet_r` is a `Base.Quantity`
and `"{:.2f}".format(Quantity)` is a `TypeError`, so the guard written to keep
a failed fillet from taking down the recompute is what takes it down.

Also in the same area: the flange neck is built from `ODp`/`T1` even when both
are zero. They are documented OPTIONAL, and `Part.makeCylinder(0, 0, ...)`
fuses a degenerate solid that leaves the flange `isValid()` False.

### Before / after

| | before | after |
|---|---|---|
| `Valve` butterfly / globe / wafer-check / ball | `NameError` | valid solid |
| `pCmd.makeElbow` in console mode | `AttributeError` | valid 4-face shell, both ports |
| `Flange` SO | NULL shape, no error | 15 faces, `isValid()` |
| `Tee` | `TypeError` | 7 faces, `isValid()` |

### Why this matters beyond my own use

`pFeatures` is already almost entirely GUI-free — it is pure `Part`/BRep with a
single `FreeCADGui` reference in `nearestPort`, which is a selection helper and
not on the geometry path. These three fixes are the remainder. With them the
workbench can be used from `freecadcmd`, from CI, and from any batch or
generative pipeline, which seems worth having.

Happy to split this into three PRs if you would rather review them separately.